### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/jet.el
+++ b/jet.el
@@ -19,6 +19,7 @@
 ;;; Code:
 
 (require 'transient)
+(require 'subr-x)
 
 (defcustom jet-command "jet"
   "The jet command name to run."


### PR DESCRIPTION
```
jet.el:76:7: Warning: ‘seq-filter’ called with 1 argument, but requires 2
jet.el:78:7: Warning: ‘seq-map’ called with 1 argument, but requires 2 or more

In jet-menu--transient-suffix-by-name:
jet.el:87:6: Warning: ‘seq-find’ called with 1 argument, but requires 2 or 3

In end of data:
jet.el:207:10: Warning: the function ‘replace-region-contents’ is not known to
    be defined.
jet.el:74:5: Warning: the function ‘thread-last’ is not known to be defined.
```