### PR TITLE
Silently fail when no region & handle defun

### DIFF
--- a/jet.el
+++ b/jet.el
@@ -74,7 +74,8 @@
   (string-trim
    (if (use-region-p)
        (buffer-substring-no-properties (region-beginning) (region-end))
-     (thing-at-point 'sexp t))))
+     (or (thing-at-point 'sexp t)
+         (thing-at-point 'defun t)))))
 
 (defun jet--major-mode-fn-for (to)
   "Return the major mode function for TO."


### PR DESCRIPTION
Currently errors when trying to use without a valid region selected, so this fall back to silently returning and also attempting to get the surrounding `defn`.

Not sure what the best behaviour here is, maybe an `if-let` is better here that `error`s with "No parseable region selected"?